### PR TITLE
Adding gambling category

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -373,5 +373,11 @@
     "name": "Work",
     "slug": "work",
     "description": "projects focused on gig economies, future of work and professional reputation"
+  },
+  
+  {
+    "name": "gambling",
+    "slug": "gambling",
+    "description": "projects focused on gambling: pokerrooms, casinos etc"
   }
 ]


### PR DESCRIPTION
Poker rooms and casinos are fundamentally different than other gaming  for obvoius reasons it should be separate by design.